### PR TITLE
Changes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [dev-packages]
 pytest = "*"
 pytest-cov = "*"
-python-coveralls = "*"
+coveralls = "*"
 mock = "*"
 "flake8" = "*"
 bpython = "*"

--- a/pytac/load_csv.py
+++ b/pytac/load_csv.py
@@ -11,12 +11,13 @@ The csv files are stored in one directory with specified names:
 
 """
 from __future__ import print_function
-import sys
 import os
 import csv
 import pytac
-from pytac import epics, data_source, units, utils
 import collections
+from pytac import epics, data_source, units, utils
+from pytac.exceptions import LatticeException
+
 
 # Create a default unit conversion object that returns the input unchanged.
 UNIT_UC = units.PolyUnitConv([1, 0])
@@ -164,9 +165,8 @@ def load(mode, control_system=None, directory=None):
             from pytac import cothread_cs
             control_system = cothread_cs.CothreadControlSystem()
     except ImportError:
-        print('To load a lattice using the default control system, please'
-              ' install cothread.', file=sys.stderr)
-        return None
+        raise LatticeException('Please install cothread to load a lattice using'
+                               ' the default control system (in cothread_cs.py)')
     if directory is None:
         directory = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                  'data')

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -1,4 +1,68 @@
-# No imports needed.
+import sys
+import pytac
+import pytest
+from mock import patch
+from types import ModuleType
+from pytac.load_csv import load
+from pytac.exceptions import LatticeException
+
+
+@pytest.fixture(scope="session")
+def Travis_CI_compatibility():
+    """Travis CI cannot import cothread so we must create a mock of cothread and
+        catools (the module that pytac imports from cothread), including the
+        functions that pytac explicitly imports (caget and caput).
+    """
+    class catools(object):
+        def caget():
+            pass
+
+        def caput():
+            pass
+
+    cothread = ModuleType('cothread')
+    cothread.catools = catools
+    sys.modules['cothread'] = cothread
+    sys.modules['cothread.catools'] = catools
+
+
+@pytest.fixture(scope="session")
+def mock_cs_raises_ImportError():
+    """We create a mock control system to replace CothreadControlSystem, so that
+        we can check that when it raises an ImportError load_csv.load catches it
+        and raises a LatticeException instead.
+    N.B. Our new CothreadControlSystem is nested inside a fixture so it can be
+     patched into pytac.cothread_cs to replace the existing
+     CothreadControlSystem class. The new CothreadControlSystem created here is
+     a function not a class (like the original) to prevent it from raising the
+     ImportError when the code is compiled.
+    """
+    def CothreadControlSystem():
+        raise ImportError
+    return CothreadControlSystem
+
+
+def test_default_control_system_import(Travis_CI_compatibility):
+    """In this test we:
+        - assert that the lattice is indeed loaded if no execeptions are raised.
+        - assert that the default control system is indeed cothread and that it
+           is loaded onto the lattice correctly.
+    """
+    assert bool(load('VMX'))
+    assert isinstance(load('VMX')._cs, pytac.cothread_cs.CothreadControlSystem)
+
+
+def test_import_fail_raises_LatticeException(Travis_CI_compatibility,
+                                             mock_cs_raises_ImportError):
+    """In this test we:
+        - check that load corectly fails if cothread cannot be imported.
+        - check that when the import of the CothreadControlSystem fails the
+           ImportError raised is replaced with a LatticeException.
+    """
+    with patch('pytac.cothread_cs.CothreadControlSystem',
+               mock_cs_raises_ImportError):
+        with pytest.raises(LatticeException):
+            load('VMX')
 
 
 def test_elements_loaded(lattice):


### PR DESCRIPTION
- Fixed the dependency issues caused by the latest version of pytest-cov.
- Updated load_csv.load() to throw a LatticeException, instead of an ImportError and print statement, when importing cothread fails.
- Added tests for load_csv.load() when control_system=None, to test the default control system (cothread) loads correctly and test that a LatticeException is raised if cothread fails to import; this boosted the test coverage of load_csv to 100%.