### PR TITLE
Simplify mocking cothread for testing purposes.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,9 @@
 import os
 import mock
 import pytest
+import sys
+import types
+
 import pytac
 from pytac import load_csv
 from pytac.element import Element
@@ -9,6 +12,27 @@ from pytac.data_source import DataSourceManager, DeviceDataSource
 from pytac.units import PolyUnitConv
 from pytac.epics import EpicsLattice, EpicsElement, EpicsDevice
 from constants import DUMMY_VALUE_1, DUMMY_VALUE_2, RB_PV, SP_PV, LATTICE_NAME, CURRENT_DIR, DUMMY_ARRAY
+
+
+def pytest_sessionstart():
+    """Create a dummy cothread module.
+
+    cothread is not trivial to import, so it is better to mock it before any
+    tests run. In particular, we need catools (the module that pytac imports
+    from cothread), including the functions that pytac explicitly imports
+    (caget and caput).
+    """
+    cothread = types.ModuleType('cothread')
+
+    catools = types.ModuleType('catools')
+    catools.caget = mock.MagicMock()
+    catools.caput = mock.MagicMock()
+    catools.ca_nothing = mock.MagicMock()
+
+    cothread.catools = catools
+
+    sys.modules['cothread'] = cothread
+    sys.modules['cothread.catools'] = catools
 
 
 # Create mock devices and attach them to the element

--- a/test/test_cothread_cs.py
+++ b/test/test_cothread_cs.py
@@ -1,0 +1,19 @@
+"""Tests for the CothreadControlSystem class.
+
+This module depends on the cothread module being mocked.
+
+See conftest.py for more.
+"""
+from cothread import catools
+import pytest
+from pytac.cothread_cs import CothreadControlSystem
+
+
+@pytest.fixture
+def cs():
+    return CothreadControlSystem()
+
+
+def test_get_single_calls_caget(cs):
+    cs.get('abc')
+    catools.caget.assert_called_with('abc')

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -1,31 +1,10 @@
-import sys
 import pytac
 import pytest
 from mock import patch
-from types import ModuleType
 from pytac.load_csv import load
 
 
-@pytest.fixture(scope="session")
-def Travis_CI_compatibility():
-    """Travis CI cannot import cothread so we must create a mock of cothread and
-        catools (the module that pytac imports from cothread), including the
-        functions that pytac explicitly imports (caget and caput).
-    """
-    class catools(object):
-        def caget():
-            pass
-
-        def caput():
-            pass
-
-    cothread = ModuleType('cothread')
-    cothread.catools = catools
-    sys.modules['cothread'] = cothread
-    sys.modules['cothread.catools'] = catools
-
-
-@pytest.fixture(scope="session")
+@pytest.fixture
 def mock_cs_raises_ImportError():
     """We create a mock control system to replace CothreadControlSystem, so that
         we can check that when it raises an ImportError load_csv.load catches it
@@ -41,7 +20,7 @@ def mock_cs_raises_ImportError():
     return CothreadControlSystem
 
 
-def test_default_control_system_import(Travis_CI_compatibility):
+def test_default_control_system_import():
     """In this test we:
         - assert that the lattice is indeed loaded if no execeptions are raised.
         - assert that the default control system is indeed cothread and that it
@@ -51,8 +30,7 @@ def test_default_control_system_import(Travis_CI_compatibility):
     assert isinstance(load('VMX')._cs, pytac.cothread_cs.CothreadControlSystem)
 
 
-def test_import_fail_raises_ControlSystemException(Travis_CI_compatibility,
-                                                   mock_cs_raises_ImportError):
+def test_import_fail_raises_ControlSystemException(mock_cs_raises_ImportError):
     """In this test we:
         - check that load corectly fails if cothread cannot be imported.
         - check that when the import of the CothreadControlSystem fails the


### PR DESCRIPTION
This means that any of the code that imports cothread can be tested.