### PR TITLE
Miscellaneous changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ To run the tests::
 
  $ python -m pytest
 
-To see a coverage report, check pep8 and pyflakes::
+To see a coverage report, check pytest-cov::
 
- $ python -m pytest --cov=pytac --pep8 --flakes
+ $ python -m pytest --cov-report term-missing --cov=pytac
 
 To build the documentation::
 

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -2,7 +2,7 @@ Developers
 ==========
 
 The installation and initialisation steps are slightly different if you want to work on pytac.
-N.B. This guide uses pipenv but a normal venv will also work.
+N.B. This guide uses pipenv but a virtualenv will also work.
 
 
 Installation

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -67,9 +67,9 @@ Print BPM PV names along with s position
     ...
     >>> lattice.get_family_s('BPM')
     [4.38,
-     8.806500000000002,
-     11.374000000000002,
-     ...
+    8.806500000000002,
+    11.374000000000002,
+    ...
 
 Get the value of the 'b1' field of the quad elements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -90,6 +90,6 @@ Get the value of the 'b1' field of the quad elements
 
     >>> lattice.get_values('QUAD', 'b1', pytac.RB)
     [71.32496643066406,
-     129.35191345214844,
-     98.25287628173828,
+    129.35191345214844,
+    98.25287628173828,
     ...

--- a/docs/pytac.rst
+++ b/docs/pytac.rst
@@ -6,10 +6,18 @@ API Documentation
     :undoc-members:
     :show-inheritance:
 
-pytac.cs module
+pytac.cothread_cs module
 ---------------
 
-.. automodule:: pytac.cs
+.. automodule:: pytac.cothread_cs
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+pytac.data_source module
+-------------------
+
+.. automodule:: pytac.data_source
     :members:
     :undoc-members:
     :show-inheritance:
@@ -30,6 +38,14 @@ pytac.element module
     :undoc-members:
     :show-inheritance:
 
+pytac.exceptions module
+--------------------
+
+.. automodule:: pytac.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 pytac.lattice module
 --------------------
 
@@ -42,14 +58,6 @@ pytac.load_csv module
 ---------------------
 
 .. automodule:: pytac.load_csv
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-pytac.model module
----------------------
-
-.. automodule:: pytac.model
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/pytac.rst
+++ b/docs/pytac.rst
@@ -9,7 +9,7 @@ API Documentation
 pytac.cothread_cs module
 ---------------
 
-.. automodule:: pytac.cothread_cs
+.. automodule:: pytac.cs
     :members:
     :undoc-members:
     :show-inheritance:

--- a/pytac/__init__.py
+++ b/pytac/__init__.py
@@ -12,9 +12,10 @@ LIVE = 'live'
 DEFAULT = 'default'
 
 
-from . import data_source, element, exceptions, lattice, load_csv, units, utils  # noqa: E402
+from . import (cothread_cs, data_source, device, element, exceptions, lattice,
+               load_csv, units, utils)  # noqa: E402
 """Error 402 is suppressed as we cannot import these modules at the top of the
 file as the strings above must be set first or the imports will fail.
 """
-__all__ = ["data_source", "element", "exceptions", "lattice", "load_csv",
-           "units", "utils"]
+__all__ = ["cothread_cs", "data_source", "device", "element", "exceptions",
+           "lattice", "load_csv", "units", "utils"]

--- a/pytac/__init__.py
+++ b/pytac/__init__.py
@@ -12,10 +12,10 @@ LIVE = 'live'
 DEFAULT = 'default'
 
 
-from . import (cothread_cs, data_source, device, element, exceptions, lattice,
-               load_csv, units, utils)  # noqa: E402
+from . import (data_source, device, element, exceptions, lattice, load_csv,
+               units, utils)  # noqa: E402
 """Error 402 is suppressed as we cannot import these modules at the top of the
 file as the strings above must be set first or the imports will fail.
 """
-__all__ = ["cothread_cs", "data_source", "device", "element", "exceptions",
-           "lattice", "load_csv", "units", "utils"]
+__all__ = ["data_source", "device", "element", "exceptions", "lattice",
+           "load_csv", "units", "utils"]

--- a/pytac/cothread_cs.py
+++ b/pytac/cothread_cs.py
@@ -25,7 +25,7 @@ class CothreadControlSystem(ControlSystem):
             pv (string): The process variable given as a string. It can be a
                          readback or a setpoint PV.
             throw (bool): if True, ControlSystemException will be raised on
-                          failure
+                          failure instead of warning.
 
         Returns:
             object: the current value of the given PV.
@@ -82,7 +82,7 @@ class CothreadControlSystem(ControlSystem):
             pv (string): PV to set the value of.
             value (object): The value to set the PV to.
             throw (bool): if True, ControlSystemException will be raised on
-                          failure
+                          failure instead of warning.
 
         Returns:
             bool: True for success, False for failure

--- a/pytac/cothread_cs.py
+++ b/pytac/cothread_cs.py
@@ -24,8 +24,9 @@ class CothreadControlSystem(ControlSystem):
         Args:
             pv (string): The process variable given as a string. It can be a
                          readback or a setpoint PV.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             object: the current value of the given PV.
@@ -48,9 +49,9 @@ class CothreadControlSystem(ControlSystem):
 
         Args:
             pvs (sequence): PVs to get values of.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure. If False, None will be returned for any PV
-                          for which the get fails.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             sequence: the current values of the PVs.
@@ -81,8 +82,8 @@ class CothreadControlSystem(ControlSystem):
         Args:
             pv (string): PV to set the value of.
             value (object): The value to set the PV to.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
 
         Returns:
             bool: True for success, False for failure
@@ -107,10 +108,10 @@ class CothreadControlSystem(ControlSystem):
         Args:
             pvs (sequence): PVs to set the values of.
             values (sequence): values to set to the PVs.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure. If False, a list of True and False values
-                          will be returned corresponding to successes and
-                          failures.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False return a list of True and False values
+                           corresponding to successes and failures and log a
+                           warning.
 
         Returns:
             list(bool): True for success, False for failure

--- a/pytac/cs.py
+++ b/pytac/cs.py
@@ -15,8 +15,9 @@ class ControlSystem(object):
         Args:
             pv (string): PV to get the value of.
                          readback or a setpoint PV.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             object: the current value of the given PV.
@@ -31,9 +32,9 @@ class ControlSystem(object):
 
         Args:
             pvs (sequence): PVs to get values of.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure. If False, None will be returned for any PV
-                          for which the get fails.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             list(object): the current values of the PVs.
@@ -49,8 +50,8 @@ class ControlSystem(object):
         Args:
             pv (string): The PV to set the value of.
             value (object): The value to set the PV to.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
 
         Raises:
             ControlSystemException: if it cannot connect to the specified PV.
@@ -63,10 +64,10 @@ class ControlSystem(object):
         Args:
             pvs (sequence): PVs to set the values of.
             values (sequence): values to set no the PVs.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure. If False, a list of True and False values
-                          will be returned corresponding to successes and
-                          failures.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False return a list of True and False values
+                           corresponding to successes and failures and log a
+                           warning.
 
         Raises:
             ValueError: if the PVs or values are not passed in as sequences

--- a/pytac/cs.py
+++ b/pytac/cs.py
@@ -4,8 +4,8 @@
 class ControlSystem(object):
     """Abstract base class representing a control system.
 
-    A specialised implementation of this class would be used to communicate over
-     channel access with the hardware in the ring.
+    A specialised implementation of this class would be used to communicate
+     over channel access with the hardware in the ring.
 
     **Methods:**
     """

--- a/pytac/cs.py
+++ b/pytac/cs.py
@@ -9,14 +9,14 @@ class ControlSystem(object):
 
     **Methods:**
     """
-    def get_single(self, pv, throw=True):
+    def get_single(self, pv, throw):
         """Get the value of a given PV.
 
         Args:
             pv (string): PV to get the value of.
                          readback or a setpoint PV.
             throw (bool): if True, ControlSystemException will be raised on
-                          failure
+                          failure instead of warning.
 
         Returns:
             object: the current value of the given PV.
@@ -26,13 +26,14 @@ class ControlSystem(object):
         """
         raise NotImplementedError()
 
-    def get_multiple(self, pvs, throw=True):
+    def get_multiple(self, pvs, throw):
         """Get the value for given PVs.
 
         Args:
             pvs (sequence): PVs to get values of.
             throw (bool): if True, ControlSystemException will be raised on
-                          failure
+                          failure. If False, None will be returned for any PV
+                          for which the get fails.
 
         Returns:
             list(object): the current values of the PVs.
@@ -42,28 +43,30 @@ class ControlSystem(object):
         """
         raise NotImplementedError()
 
-    def set_single(self, pv, value):
+    def set_single(self, pv, value, throw):
         """Set the value of a given PV.
 
         Args:
             pv (string): The PV to set the value of.
             value (object): The value to set the PV to.
             throw (bool): if True, ControlSystemException will be raised on
-                          failure
+                          failure instead of warning.
 
         Raises:
             ControlSystemException: if it cannot connect to the specified PV.
         """
         raise NotImplementedError()
 
-    def set_multiple(self, pvs, values):
+    def set_multiple(self, pvs, values, throw):
         """Set the values for given PVs.
 
         Args:
             pvs (sequence): PVs to set the values of.
             values (sequence): values to set no the PVs.
             throw (bool): if True, ControlSystemException will be raised on
-                          failure
+                          failure. If False, a list of True and False values
+                          will be returned corresponding to successes and
+                          failures.
 
         Raises:
             ValueError: if the PVs or values are not passed in as sequences

--- a/pytac/data/DIAD/unitconv.csv
+++ b/pytac/data/DIAD/unitconv.csv
@@ -10,7 +10,7 @@ el_id,field,uc_type,uc_id,phys_units,eng_units
 189,db0,null,0,m^-1,A
 136,db0,null,0,m^-1,A
 164,db0,null,0,m^-1,A
-1490,f,null,0,Hz,Hz
+1492,f,null,0,Hz,Hz
 5,b1,pchip,1,m^-2,A
 404,b1,pchip,1,m^-2,A
 425,b1,pchip,1,m^-2,A

--- a/pytac/data_source.py
+++ b/pytac/data_source.py
@@ -1,6 +1,7 @@
 """Module containing pytac data source classes."""
 import pytac
-from pytac.exceptions import DataSourceException, FieldException, HandleException
+from pytac.exceptions import (DataSourceException, FieldException,
+                              HandleException)
 
 
 class DataSource(object):

--- a/pytac/data_source.py
+++ b/pytac/data_source.py
@@ -31,8 +31,9 @@ class DataSource(object):
         Args:
             field (str): field of the requested value.
             handle (str): pytac.RB or pytac.SP
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             float: value for specified field and handle.
@@ -47,8 +48,8 @@ class DataSource(object):
         Args:
             field (str): field to set.
             value (float): value to set.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
         """
         raise NotImplementedError()
 
@@ -183,8 +184,9 @@ class DataSourceManager(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS returned.
             data_source (str): pytac.LIVE or pytac.SIM.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             float: The value of the requested field
@@ -222,8 +224,8 @@ class DataSourceManager(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS.
             data_source (str): pytac.LIVE or pytac.SIM.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
 
         Raises:
             HandleException: if the specified handle is not pytac.SP.
@@ -312,8 +314,9 @@ class DeviceDataSource(DataSource):
         Args:
             field (str): field of the requested value.
             handle (str): pytac.RB or pytac.SP.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             float: The value of the PV.
@@ -334,8 +337,8 @@ class DeviceDataSource(DataSource):
         Args:
             field (str): field for the requested value.
             value (float): The value to set on the PV.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
 
         Raises:
             FieldException: if the device does not have the specified field.

--- a/pytac/device.py
+++ b/pytac/device.py
@@ -85,9 +85,9 @@ class BasicDevice(Device):
 class EpicsDevice(Device):
     """An EPICS-aware device.
 
-    Contains a control system, readback and setpoint PVs. A readback or setpoint
-    PV is required when creating an epics device otherwise a DataSourceException
-    is raised. The device is enabled by default.
+    Contains a control system, readback and setpoint PVs. A readback or
+    setpoint PV is required when creating an epics device otherwise a
+    DataSourceException is raised. The device is enabled by default.
 
     **Attributes:**
 

--- a/pytac/device.py
+++ b/pytac/device.py
@@ -30,8 +30,8 @@ class Device(object):
 
         Args:
             value (float): the value to set.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
         """
         raise NotImplementedError()
 
@@ -40,8 +40,9 @@ class Device(object):
 
         Args:
             handle (str): pytac.SP or pytac.RB.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             float: the value of the PV.
@@ -156,8 +157,8 @@ class EpicsDevice(Device):
 
         Args:
             value (float): The value to set.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
 
         Raises:
             HandleException: if no setpoint PV exists.
@@ -173,8 +174,9 @@ class EpicsDevice(Device):
 
         Args:
             handle (str): pytac.SP or pytac.RB.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             float: The value of the PV.

--- a/pytac/device.py
+++ b/pytac/device.py
@@ -25,16 +25,6 @@ class Device(object):
         """
         raise NotImplementedError()
 
-    def set_value(self, value, throw):
-        """Set the value on the device.
-
-        Args:
-            value (float): the value to set.
-            throw (bool): On failure, if True raise ControlSystemException, if
-                           False log a warning.
-        """
-        raise NotImplementedError()
-
     def get_value(self, handle, throw):
         """Read the value from the device.
 
@@ -46,6 +36,16 @@ class Device(object):
 
         Returns:
             float: the value of the PV.
+        """
+        raise NotImplementedError()
+
+    def set_value(self, value, throw):
+        """Set the value on the device.
+
+        Args:
+            value (float): the value to set.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
         """
         raise NotImplementedError()
 
@@ -73,16 +73,6 @@ class BasicDevice(Device):
         """
         return bool(self._enabled)
 
-    def set_value(self, value, throw=None):
-        """Set the value on the device.
-
-        Args:
-            value (numeric): the value to set.
-            throw (bool): Irrelevant in this case as a control system is not
-                           used, only supported to conform with the base class.
-        """
-        self.value = value
-
     def get_value(self, handle=None, throw=None):
         """Read the value from the device.
 
@@ -96,6 +86,16 @@ class BasicDevice(Device):
             numeric: the value of the device.
         """
         return self.value
+
+    def set_value(self, value, throw=None):
+        """Set the value on the device.
+
+        Args:
+            value (numeric): the value to set.
+            throw (bool): Irrelevant in this case as a control system is not
+                           used, only supported to conform with the base class.
+        """
+        self.value = value
 
 
 class EpicsDevice(Device):
@@ -152,23 +152,6 @@ class EpicsDevice(Device):
         """
         return bool(self._enabled)
 
-    def set_value(self, value, throw=True):
-        """Set the device value.
-
-        Args:
-            value (float): The value to set.
-            throw (bool): On failure, if True raise ControlSystemException, if
-                           False log a warning.
-
-        Raises:
-            HandleException: if no setpoint PV exists.
-        """
-        if self.sp_pv is None:
-            raise HandleException("Device {0} has no setpoint PV."
-                                  .format(self.name))
-        else:
-            self._cs.set_single(self.sp_pv, value, throw)
-
     def get_value(self, handle, throw=True):
         """Read the value of a readback or setpoint PV.
 
@@ -191,6 +174,23 @@ class EpicsDevice(Device):
         else:
             raise HandleException("Device {0} has no {1} PV."
                                   .format(self.name, handle))
+
+    def set_value(self, value, throw=True):
+        """Set the device value.
+
+        Args:
+            value (float): The value to set.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
+
+        Raises:
+            HandleException: if no setpoint PV exists.
+        """
+        if self.sp_pv is None:
+            raise HandleException("Device {0} has no setpoint PV."
+                                  .format(self.name))
+        else:
+            self._cs.set_single(self.sp_pv, value, throw)
 
     def get_pv_name(self, handle):
         """Get the PV name for the specified handle.

--- a/pytac/element.py
+++ b/pytac/element.py
@@ -238,6 +238,10 @@ class EpicsElement(Element):
         except KeyError:
             raise DataSourceException("No data source for field {0} on element"
                                       " {1}.".format(field, self))
+        except AttributeError:
+            raise DataSourceException("Cannot get PV for field {0} on element"
+                                      " {1}, as basic devices do not have "
+                                      "associated PV's.".format(field, self))
         except FieldException:
             raise FieldException("No field {0} on element {1}.".format(field,
                                                                        self))

--- a/pytac/element.py
+++ b/pytac/element.py
@@ -152,7 +152,7 @@ class Element(object):
         self.families.add(family)
 
     def get_value(self, field, handle=pytac.RB, units=pytac.DEFAULT,
-                  data_source=pytac.DEFAULT):
+                  data_source=pytac.DEFAULT, throw=True):
         """Get the value for a field.
 
         Returns the value of a field on the element. This value is uniquely
@@ -165,6 +165,8 @@ class Element(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS returned.
             data_source (str): pytac.LIVE or pytac.SIM.
+            throw (bool): if True, ControlSystemException will be raised on
+                          failure instead of warning.
 
         Returns:
             float: The value of the requested field
@@ -175,7 +177,7 @@ class Element(object):
         """
         try:
             return self._data_source_manager.get_value(field, handle, units,
-                                                       data_source)
+                                                       data_source, throw)
         except DataSourceException:
             raise DataSourceException("No data source {0} on element {1}."
                                       .format(data_source, self))
@@ -184,7 +186,7 @@ class Element(object):
                                  .format(self, field))
 
     def set_value(self, field, value, handle=pytac.SP, units=pytac.DEFAULT,
-                  data_source=pytac.DEFAULT):
+                  data_source=pytac.DEFAULT, throw=True):
         """Set the value for a field.
 
         This value can be set on the machine or the simulation.
@@ -195,6 +197,8 @@ class Element(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS.
             data_source (str): pytac.LIVE or pytac.SIM.
+            throw (bool): if True, ControlSystemException will be raised on
+                          failure instead of warning.
 
         Raises:
             DataSourceException: if arguments are incorrect.
@@ -202,7 +206,7 @@ class Element(object):
         """
         try:
             self._data_source_manager.set_value(field, value, handle, units,
-                                                data_source)
+                                                data_source, throw)
         except DataSourceException:
             raise DataSourceException("No data source {0} on element {1}."
                                       .format(data_source, self))

--- a/pytac/element.py
+++ b/pytac/element.py
@@ -165,8 +165,9 @@ class Element(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS returned.
             data_source (str): pytac.LIVE or pytac.SIM.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             float: The value of the requested field
@@ -197,8 +198,8 @@ class Element(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS.
             data_source (str): pytac.LIVE or pytac.SIM.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
 
         Raises:
             DataSourceException: if arguments are incorrect.

--- a/pytac/lattice.py
+++ b/pytac/lattice.py
@@ -23,7 +23,7 @@ class Lattice(object):
         name (str): The name of the lattice.
 
     .. Private Attributes:
-           _lattice (list): The list of all the element objects in the lattice.
+           _elements (list): The list of all the element objects in the lattice
            _cs (ControlSystem): The control system used to store the values on
                                  a PV.
            _data_source_manager (DataSourceManager): A class that manages the
@@ -37,12 +37,13 @@ class Lattice(object):
         **Methods:**
         """
         self.name = name
-        self._lattice = []
+        self._elements = []
         self._data_source_manager = DataSourceManager()
 
     def __getitem__(self, n):
-        """Get the (n + 1)th element of the lattice - i.e. index 0 represents
-        the first element in the lattice.
+        """Get the (n + 1)th element of the lattice.
+
+        i.e. index 0 represents the first element in the lattice.
 
         Args:
             n (int): index.
@@ -50,18 +51,15 @@ class Lattice(object):
         Returns:
             Element: indexed element.
         """
-        return self._lattice[n]
+        return self._elements[n]
 
     def __len__(self):
         """The number of elements in the lattice.
 
-        When using the len function returns the number of elements in
-        the lattice.
-
         Returns:
             int: The number of elements in the lattice.
         """
-        return len(self._lattice)
+        return len(self._elements)
 
     def set_data_source(self, data_source, data_source_type):
         """Add a data source to the lattice.
@@ -161,8 +159,9 @@ class Lattice(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS returned.
             data_source (str): pytac.LIVE or pytac.SIM.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False None will be returned for any PV that fails
+                           and log a warning.
 
         Returns:
             float: The value of the requested field
@@ -193,8 +192,8 @@ class Lattice(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS.
             data_source (str): pytac.LIVE or pytac.SIM.
-            throw (bool): if True, ControlSystemException will be raised on
-                          failure instead of warning.
+            throw (bool): On failure, if True raise ControlSystemException, if
+                           False log a warning.
 
         Raises:
             DataSourceException: if arguments are incorrect.
@@ -217,7 +216,7 @@ class Lattice(object):
             float: The length of the lattice (m).
         """
         total_length = 0
-        for e in self._lattice:
+        for e in self._elements:
             total_length += e.length
         return total_length
 
@@ -227,7 +226,7 @@ class Lattice(object):
         Args:
             element (Element): element to append.
         """
-        self._lattice.append(element)
+        self._elements.append(element)
 
     def get_elements(self, family=None, cell=None):
         """Get the elements of a family from the lattice.
@@ -247,11 +246,11 @@ class Lattice(object):
                          family.
         """
         if family is None:
-            elements = self._lattice
+            elements = self._elements[:]
             if len(elements) == 0:
                 raise ValueError("No elements in lattice {0}.".format(self))
         else:
-            elements = [e for e in self._lattice if family in e.families]
+            elements = [e for e in self._elements if family in e.families]
             if len(elements) == 0:
                 raise ValueError("No elements in family {0}.".format(family))
         if cell is not None:
@@ -267,7 +266,7 @@ class Lattice(object):
             set: all defined families.
         """
         families = set()
-        for element in self._lattice:
+        for element in self._elements:
             families.update(element.families)
         return families
 

--- a/pytac/lattice.py
+++ b/pytac/lattice.py
@@ -148,7 +148,7 @@ class Lattice(object):
                                  "lattice {1}.".format(field, self))
 
     def get_value(self, field, handle=pytac.RB, units=pytac.DEFAULT,
-                  data_source=pytac.DEFAULT):
+                  data_source=pytac.DEFAULT, throw=True):
         """Get the value for a field on the lattice.
 
         Returns the value of a field on the lattice. This value is uniquely
@@ -161,6 +161,8 @@ class Lattice(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS returned.
             data_source (str): pytac.LIVE or pytac.SIM.
+            throw (bool): if True, ControlSystemException will be raised on
+                          failure instead of warning.
 
         Returns:
             float: The value of the requested field
@@ -171,7 +173,7 @@ class Lattice(object):
         """
         try:
             return self._data_source_manager.get_value(field, handle, units,
-                                                       data_source)
+                                                       data_source, throw)
         except DataSourceException:
             raise DataSourceException("No data source {0} on lattice {1}."
                                       .format(data_source, self))
@@ -180,7 +182,7 @@ class Lattice(object):
                                  "source {2}".format(self, field, data_source))
 
     def set_value(self, field, value, handle=pytac.SP, units=pytac.DEFAULT,
-                  data_source=pytac.DEFAULT):
+                  data_source=pytac.DEFAULT, throw=True):
         """Set the value for a field.
 
         This value can be set on the machine or the simulation.
@@ -191,6 +193,8 @@ class Lattice(object):
             handle (str): pytac.SP or pytac.RB.
             units (str): pytac.ENG or pytac.PHYS.
             data_source (str): pytac.LIVE or pytac.SIM.
+            throw (bool): if True, ControlSystemException will be raised on
+                          failure instead of warning.
 
         Raises:
             DataSourceException: if arguments are incorrect.
@@ -198,7 +202,7 @@ class Lattice(object):
         """
         try:
             self._data_source_manager.set_value(field, value, handle, units,
-                                                data_source)
+                                                data_source, throw)
         except DataSourceException:
             raise DataSourceException("No data source {0} on lattice {1}."
                                       .format(data_source, self))

--- a/pytac/lattice.py
+++ b/pytac/lattice.py
@@ -459,8 +459,12 @@ class EpicsLattice(Lattice):
             return (self._data_source_manager._data_sources[pytac.LIVE]
                     .get_device(field).get_pv_name(handle))
         except KeyError:
-            raise DataSourceException('Lattice {0} has no device for field {1}.'
-                                      .format(self, field))
+            raise DataSourceException("Lattice {0} has no device for field"
+                                      " {1}.".format(self, field))
+        except AttributeError:
+            raise DataSourceException("Cannot get PV for field {0} on lattice"
+                                      " {1}, as basic devices do not have "
+                                      "associated PV's.".format(field, self))
 
     def get_element_pv_names(self, family, field, handle):
         """Get all PV names for a specific family, field, and handle.

--- a/pytac/load_csv.py
+++ b/pytac/load_csv.py
@@ -126,7 +126,7 @@ def load_unitconv(directory, mode, lattice):
     with open(os.path.join(directory, mode, UNITCONV_FILENAME)) as unitconv:
         csv_reader = csv.DictReader(unitconv)
         for item in csv_reader:
-            if int(item['el_id']) is 0:
+            if int(item['el_id']) == 0:
                 if item['uc_type'] != 'null':
                     lattice._data_source_manager._uc[item['field']] = unitconvs[int(item['uc_id'])]
                     lattice._data_source_manager._uc[item['field']].phys_units = item['phys_units']
@@ -140,7 +140,8 @@ def load_unitconv(directory, mode, lattice):
                 if item['uc_type'] == 'null':
                     element._data_source_manager._uc[item['field']] = units.NullUnitConv(item['eng_units'], item['phys_units'])
                 else:
-                    if element.families.intersection(('HSTR', 'VSTR', 'QUAD', 'SEXT')):
+                    if element.families.intersection(('HSTR', 'VSTR', 'QUAD',
+                                                      'SEXT')):
                         unitconvs[int(item['uc_id'])]._post_eng_to_phys = get_div_rigidity(lattice.get_value('energy', units=pytac.PHYS))
                         unitconvs[int(item['uc_id'])]._pre_phys_to_eng = get_mult_rigidity(lattice.get_value('energy', units=pytac.PHYS))
                     element._data_source_manager._uc[item['field']] = unitconvs[int(item['uc_id'])]

--- a/pytac/load_csv.py
+++ b/pytac/load_csv.py
@@ -29,34 +29,6 @@ POLY_FILENAME = 'uc_poly_data.csv'
 PCHIP_FILENAME = 'uc_pchip_data.csv'
 
 
-def get_div_rigidity(energy):
-    """
-    Args:
-        energy (int):
-    Returns:
-        function: div rigidity.
-    """
-    rigidity = utils.rigidity(energy)
-
-    def div_rigidity(value):
-        return value / rigidity
-    return div_rigidity
-
-
-def get_mult_rigidity(energy):
-    """
-    Args:
-        energy (int):
-    Returns:
-        function: mult rigidity.
-    """
-    rigidity = utils.rigidity(energy)
-
-    def mult_rigidity(value):
-        return value * rigidity
-    return mult_rigidity
-
-
 def load_poly_unitconv(filename):
     """Load polynomial unit conversions from a csv file.
 
@@ -142,8 +114,8 @@ def load_unitconv(directory, mode, lattice):
                 else:
                     if element.families.intersection(('HSTR', 'VSTR', 'QUAD',
                                                       'SEXT')):
-                        unitconvs[int(item['uc_id'])]._post_eng_to_phys = get_div_rigidity(lattice.get_value('energy', units=pytac.PHYS))
-                        unitconvs[int(item['uc_id'])]._pre_phys_to_eng = get_mult_rigidity(lattice.get_value('energy', units=pytac.PHYS))
+                        unitconvs[int(item['uc_id'])]._post_eng_to_phys = utils.get_div_rigidity(lattice.get_value('energy', units=pytac.PHYS))
+                        unitconvs[int(item['uc_id'])]._pre_phys_to_eng = utils.get_mult_rigidity(lattice.get_value('energy', units=pytac.PHYS))
                     element._data_source_manager._uc[item['field']] = unitconvs[int(item['uc_id'])]
                     element._data_source_manager._uc[item['field']].phys_units = item['phys_units']
                     element._data_source_manager._uc[item['field']].eng_units = item['eng_units']

--- a/pytac/utils.py
+++ b/pytac/utils.py
@@ -9,10 +9,10 @@ electron_mass_mev, _, _ = (scipy.constants
                            .physical_constants[electron_mass_name])
 
 
-def rigidity(energy_mev):
+def get_rigidity(energy_mev):
     """
     Args:
-        energy_mev (int):
+        energy_mev (int): the energy of the lattice.
 
     Returns:
         float: p devided by the elementary charge.
@@ -22,3 +22,33 @@ def rigidity(energy_mev):
     energy_j = energy_mev * 1e6 * scipy.constants.e
     p = beta * energy_j / scipy.constants.c
     return p / scipy.constants.e
+
+
+def get_div_rigidity(energy):
+    """
+    Args:
+        energy (int): the energy of the lattice.
+
+    Returns:
+        function: div rigidity.
+    """
+    rigidity = get_rigidity(energy)
+
+    def div_rigidity(value):
+        return value / rigidity
+    return div_rigidity
+
+
+def get_mult_rigidity(energy):
+    """
+    Args:
+        energy (int): the energy of the lattice.
+
+    Returns:
+        function: mult rigidity.
+    """
+    rigidity = get_rigidity(energy)
+
+    def mult_rigidity(value):
+        return value * rigidity
+    return mult_rigidity

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ from constants import CURRENT_DIR, DUMMY_ARRAY, DUMMY_VALUE_1, DUMMY_VALUE_2, LA
 import pytac
 from pytac import load_csv
 from pytac.data_source import DataSourceManager, DeviceDataSource
-from pytac.device import EpicsDevice
+from pytac.device import EpicsDevice, BasicDevice
 from pytac.element import Element, EpicsElement
 from pytac.lattice import EpicsLattice, Lattice
 from pytac.units import PolyUnitConv
@@ -147,22 +147,26 @@ def mock_cs():
 @pytest.fixture
 def simple_epics_element(mock_cs, unit_uc):
     element = EpicsElement(1, 0, 'BPM', 0.0, cell=1)
+    basic_device = BasicDevice(0)
     x_device = EpicsDevice('x_device', mock_cs, True, RB_PV, SP_PV)
     y_device = EpicsDevice('y_device', mock_cs, True, SP_PV, RB_PV)
     element.add_to_family('family')
     element.set_data_source(DeviceDataSource(), pytac.LIVE)
+    element.add_device('basic', basic_device, unit_uc)
     element.add_device('x', x_device, unit_uc)
     element.add_device('y', y_device, unit_uc)
     return element
 
 
 @pytest.fixture
-def simple_epics_lattice(simple_epics_element, mock_cs):
+def simple_epics_lattice(simple_epics_element, mock_cs, unit_uc):
     lat = EpicsLattice('lattice', mock_cs)
     lat.add_element(simple_epics_element)
+    basic_device = BasicDevice(0)
     x_device = EpicsDevice('x_device', mock_cs, True, RB_PV, SP_PV)
     y_device = EpicsDevice('y_device', mock_cs, True, SP_PV, RB_PV)
     lat.set_data_source(DeviceDataSource(), pytac.LIVE)
+    lat.add_device('basic', basic_device, unit_uc)
     lat.add_device('x', x_device, unit_uc)
     lat.add_device('y', y_device, unit_uc)
     return lat

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,8 @@ import types
 import mock
 import pytest
 
-from constants import CURRENT_DIR, DUMMY_ARRAY, DUMMY_VALUE_1, DUMMY_VALUE_2, LATTICE_NAME, RB_PV, SP_PV
+from constants import (CURRENT_DIR, DUMMY_ARRAY, DUMMY_VALUE_1, DUMMY_VALUE_2,
+                       LATTICE_NAME, RB_PV, SP_PV)
 import pytac
 from pytac import load_csv
 from pytac.data_source import DataSourceManager, DeviceDataSource

--- a/test/test_cothread_cs.py
+++ b/test/test_cothread_cs.py
@@ -20,7 +20,7 @@ def cs():
 
 def test_get_single_calls_caget_correctly(cs):
     caget.return_value = 42
-    assert cs.get_single(RB_PV) is 42
+    assert cs.get_single(RB_PV) == 42
     caget.assert_called_with(RB_PV, throw=True, timeout=1.0)
 
 

--- a/test/test_data_source.py
+++ b/test/test_data_source.py
@@ -56,4 +56,5 @@ def test_get_value_sim(simple_object):
 def test_unit_conversion(simple_object, double_uc):
     simple_object.set_value('y', DUMMY_VALUE_2, pytac.SP, pytac.PHYS,
                             pytac.LIVE)
-    simple_object.get_device('y').set_value.assert_called_with(DUMMY_VALUE_2 / 2)
+    simple_object.get_device('y').set_value.assert_called_with(DUMMY_VALUE_2 /
+                                                               2)

--- a/test/test_data_source.py
+++ b/test/test_data_source.py
@@ -56,5 +56,4 @@ def test_get_value_sim(simple_object):
 def test_unit_conversion(simple_object, double_uc):
     simple_object.set_value('y', DUMMY_VALUE_2, pytac.SP, pytac.PHYS,
                             pytac.LIVE)
-    simple_object.get_device('y').set_value.assert_called_with(DUMMY_VALUE_2 /
-                                                               2)
+    simple_object.get_device('y').set_value.assert_called_with(DUMMY_VALUE_2 / 2)

--- a/test/test_data_source.py
+++ b/test/test_data_source.py
@@ -37,7 +37,8 @@ def test_get_fields(simple_object):
 def test_set_value(simple_object):
     simple_object.set_value('x', DUMMY_VALUE_2, pytac.SP, pytac.ENG,
                             pytac.LIVE)
-    simple_object.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2)
+    simple_object.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2,
+                                                               True)
 
 
 @pytest.mark.parametrize('simple_object',
@@ -56,4 +57,4 @@ def test_get_value_sim(simple_object):
 def test_unit_conversion(simple_object, double_uc):
     simple_object.set_value('y', DUMMY_VALUE_2, pytac.SP, pytac.PHYS,
                             pytac.LIVE)
-    simple_object.get_device('y').set_value.assert_called_with(DUMMY_VALUE_2 / 2)
+    simple_object.get_device('y').set_value.assert_called_with(DUMMY_VALUE_2 / 2, True)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -25,7 +25,7 @@ def create_basic_device(value=1.0, enabled=True):
 def test_set_epics_device_value():
     device = create_epics_device()
     device.set_value(40)
-    device._cs.set_single.assert_called_with(SP_PV, 40)
+    device._cs.set_single.assert_called_with(SP_PV, 40, True)
 
 
 def test_get_epics_device_value():

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -85,9 +85,7 @@ def test_device_is_enabled_returns_bool_value(device_creation_function):
 
 
 # PvEnabler test.
-def test_PvEnabler():
-    mock_cs = mock.MagicMock()
-    mock_cs.get_single.return_value = 40.0
+def test_PvEnabler(mock_cs):
     pve = PvEnabler('enable-pv', 40, mock_cs)
     assert pve
     mock_cs.get_single.return_value = 50

--- a/test/test_element.py
+++ b/test/test_element.py
@@ -18,7 +18,7 @@ def test_add_element_to_family():
     assert 'fam' in e.families
 
 
-def test_device_methods_raise_DataSourceException_if_no_device_data_sorce(simple_element):
+def test_device_methods_raise_DataSourceException_if_no_live_data_source(simple_element):
     basic_element = simple_element
     del basic_element._data_source_manager._data_sources[pytac.LIVE]
     d = pytac.device.BasicDevice(0)
@@ -53,8 +53,9 @@ def test_get_value_uses_uc_if_necessary_for_cs_call(simple_element, double_uc):
 
 def test_get_value_uses_uc_if_necessary_for_sim_call(simple_element, double_uc):
     simple_element._data_source_manager._uc['x'] = double_uc
-    assert simple_element.get_value('x', handle=pytac.SP, data_source=pytac.SIM,
-                                    units=pytac.ENG) == (DUMMY_VALUE_2 / 2)
+    assert simple_element.get_value('x', handle=pytac.SP, units=pytac.ENG,
+                                    data_source=pytac.SIM) == (DUMMY_VALUE_2 /
+                                                               2)
     simple_element._data_source_manager._data_sources[pytac.SIM].get_value.assert_called_with('x', pytac.SP)
 
 
@@ -69,7 +70,8 @@ def test_set_value_phys(simple_element, double_uc):
     simple_element.set_value('x', DUMMY_VALUE_2, handle=pytac.SP,
                              units=pytac.PHYS)
     # Conversion fron physics to engineering units
-    simple_element.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2 / 2)
+    simple_element.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2 /
+                                                                2)
 
 
 def test_set_exceptions(simple_element, unit_uc):
@@ -80,10 +82,9 @@ def test_set_exceptions(simple_element, unit_uc):
     with pytest.raises(pytac.exceptions.DataSourceException):
         simple_element.set_value('y', 40.0, 'setpoint',
                                  data_source='unknown_data_source')
-    simple_element._data_source_manager._uc['uc_but_not_data_source_field'] = unit_uc
+    simple_element._data_source_manager._uc['uc_but_no_data_source'] = unit_uc
     with pytest.raises(pytac.exceptions.FieldException):
-        simple_element.set_value('uc_but_not_data_source_field', 40.0,
-                                 'setpoint')
+        simple_element.set_value('uc_but_no_data_source', 40.0, 'setpoint')
 
 
 def test_get_exceptions(simple_element):

--- a/test/test_element.py
+++ b/test/test_element.py
@@ -55,13 +55,16 @@ def test_get_value_uses_uc_if_necessary_for_sim_call(simple_element, double_uc):
     simple_element._data_source_manager._uc['x'] = double_uc
     assert simple_element.get_value('x', handle=pytac.SP, units=pytac.ENG,
                                     data_source=pytac.SIM) == (DUMMY_VALUE_2 / 2)
-    simple_element._data_source_manager._data_sources[pytac.SIM].get_value.assert_called_with('x', pytac.SP)
+    simple_element._data_source_manager._data_sources[pytac.SIM].get_value.assert_called_with('x',
+                                                                                              pytac.SP,
+                                                                                              True)
 
 
 def test_set_value_eng(simple_element):
     simple_element.set_value('x', DUMMY_VALUE_2, handle=pytac.SP)
     # No conversion needed
-    simple_element.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2)
+    simple_element.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2,
+                                                                True)
 
 
 def test_set_value_phys(simple_element, double_uc):
@@ -69,7 +72,8 @@ def test_set_value_phys(simple_element, double_uc):
     simple_element.set_value('x', DUMMY_VALUE_2, handle=pytac.SP,
                              units=pytac.PHYS)
     # Conversion fron physics to engineering units
-    simple_element.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2 / 2)
+    simple_element.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2 / 2,
+                                                                True)
 
 
 def test_set_exceptions(simple_element, unit_uc):

--- a/test/test_element.py
+++ b/test/test_element.py
@@ -54,8 +54,7 @@ def test_get_value_uses_uc_if_necessary_for_cs_call(simple_element, double_uc):
 def test_get_value_uses_uc_if_necessary_for_sim_call(simple_element, double_uc):
     simple_element._data_source_manager._uc['x'] = double_uc
     assert simple_element.get_value('x', handle=pytac.SP, units=pytac.ENG,
-                                    data_source=pytac.SIM) == (DUMMY_VALUE_2 /
-                                                               2)
+                                    data_source=pytac.SIM) == (DUMMY_VALUE_2 / 2)
     simple_element._data_source_manager._data_sources[pytac.SIM].get_value.assert_called_with('x', pytac.SP)
 
 
@@ -70,8 +69,7 @@ def test_set_value_phys(simple_element, double_uc):
     simple_element.set_value('x', DUMMY_VALUE_2, handle=pytac.SP,
                              units=pytac.PHYS)
     # Conversion fron physics to engineering units
-    simple_element.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2 /
-                                                                2)
+    simple_element.get_device('x').set_value.assert_called_with(DUMMY_VALUE_2 / 2)
 
 
 def test_set_exceptions(simple_element, unit_uc):

--- a/test/test_epics.py
+++ b/test/test_epics.py
@@ -51,11 +51,11 @@ def test_get_value_uses_cs_if_data_source_live(simple_epics_element):
     simple_epics_element.get_value('x', handle=pytac.SP,
                                    data_source=pytac.LIVE)
     simple_epics_element.get_device('x')._cs.get_single.assert_called_with(SP_PV,
-                                                                       True)
+                                                                           True)
     simple_epics_element.get_value('x', handle=pytac.RB,
                                    data_source=pytac.LIVE)
     simple_epics_element.get_device('x')._cs.get_single.assert_called_with(RB_PV,
-                                                                       True)
+                                                                           True)
 
 
 def test_get_value_raises_HandleExceptions(simple_epics_element):

--- a/test/test_epics.py
+++ b/test/test_epics.py
@@ -5,14 +5,14 @@ from constants import DUMMY_ARRAY, RB_PV, SP_PV
 import pytac
 
 
-def test_get_values(simple_epics_lattice):
+def test_get_values(simple_epics_lattice, mock_cs):
     simple_epics_lattice.get_element_values('family', 'x', pytac.RB)
-    simple_epics_lattice._cs.get_multiple.assert_called_with([RB_PV])
+    mock_cs.get_multiple.assert_called_with([RB_PV])
 
 
-def test_set_element_values(simple_epics_lattice):
+def test_set_element_values(simple_epics_lattice, mock_cs):
     simple_epics_lattice.set_element_values('family', 'x', [1])
-    simple_epics_lattice._cs.set_multiple.assert_called_with([SP_PV], [1])
+    mock_cs.set_multiple.assert_called_with([SP_PV], [1])
 
 
 @pytest.mark.parametrize('dtype, expected',
@@ -24,11 +24,11 @@ def test_set_element_values(simple_epics_lattice):
                                                     dtype=numpy.bool_)),
                           (None, DUMMY_ARRAY)))
 def test_get_values_returns_numpy_array_if_requested(simple_epics_lattice,
-                                                     dtype, expected):
+                                                     dtype, expected, mock_cs):
     values = simple_epics_lattice.get_element_values('family', 'x', pytac.RB,
                                                      dtype=dtype)
     numpy.testing.assert_equal(values, expected)
-    simple_epics_lattice._cs.get_multiple.assert_called_with([RB_PV])
+    mock_cs.get_multiple.assert_called_with([RB_PV])
 
 
 @pytest.mark.parametrize('pv_type', ['readback', 'setpoint'])
@@ -47,15 +47,13 @@ def test_get_lattice_pv_name(pv_type, simple_epics_lattice):
         simple_epics_lattice.get_pv_name('not_a_field', pv_type)
 
 
-def test_get_value_uses_cs_if_data_source_live(simple_epics_element):
+def test_get_value_uses_cs_if_data_source_live(simple_epics_element, mock_cs):
     simple_epics_element.get_value('x', handle=pytac.SP,
                                    data_source=pytac.LIVE)
-    simple_epics_element.get_device('x')._cs.get_single.assert_called_with(SP_PV,
-                                                                           True)
+    mock_cs.get_single.assert_called_with(SP_PV, True)
     simple_epics_element.get_value('x', handle=pytac.RB,
                                    data_source=pytac.LIVE)
-    simple_epics_element.get_device('x')._cs.get_single.assert_called_with(RB_PV,
-                                                                           True)
+    mock_cs.get_single.assert_called_with(RB_PV, True)
 
 
 def test_get_value_raises_HandleExceptions(simple_epics_element):

--- a/test/test_epics.py
+++ b/test/test_epics.py
@@ -63,6 +63,8 @@ def test_get_value_raises_HandleExceptions(simple_epics_element):
 
 def test_lattice_get_pv_name_raises_DataSourceException(simple_epics_lattice):
     basic_epics_lattice = simple_epics_lattice
+    with pytest.raises(pytac.exceptions.DataSourceException):
+        basic_epics_lattice.get_pv_name('basic', pytac.RB)
     del basic_epics_lattice._data_source_manager._data_sources[pytac.LIVE]
     with pytest.raises(pytac.exceptions.DataSourceException):
         basic_epics_lattice.get_pv_name('x', pytac.RB)
@@ -79,6 +81,8 @@ def test_element_get_pv_name_raises_exceptions(simple_epics_element):
     with pytest.raises(pytac.exceptions.FieldException):
         simple_epics_element.get_pv_name('unknown_field', 'setpoint')
     basic_epics_element = simple_epics_element
+    with pytest.raises(pytac.exceptions.DataSourceException):
+        basic_epics_element.get_pv_name('basic', pytac.RB)
     del basic_epics_element._data_source_manager._data_sources[pytac.LIVE]
     with pytest.raises(pytac.exceptions.DataSourceException):
         basic_epics_element.get_pv_name('x', pytac.RB)

--- a/test/test_epics.py
+++ b/test/test_epics.py
@@ -50,10 +50,12 @@ def test_get_lattice_pv_name(pv_type, simple_epics_lattice):
 def test_get_value_uses_cs_if_data_source_live(simple_epics_element):
     simple_epics_element.get_value('x', handle=pytac.SP,
                                    data_source=pytac.LIVE)
-    simple_epics_element.get_device('x')._cs.get_single.assert_called_with(SP_PV)
+    simple_epics_element.get_device('x')._cs.get_single.assert_called_with(SP_PV,
+                                                                       True)
     simple_epics_element.get_value('x', handle=pytac.RB,
                                    data_source=pytac.LIVE)
-    simple_epics_element.get_device('x')._cs.get_single.assert_called_with(RB_PV)
+    simple_epics_element.get_device('x')._cs.get_single.assert_called_with(RB_PV,
+                                                                       True)
 
 
 def test_get_value_raises_HandleExceptions(simple_epics_element):

--- a/test/test_invalid_classes.py
+++ b/test/test_invalid_classes.py
@@ -6,13 +6,13 @@ from pytac import cs, data_source, device
 def test_ControlSystem_throws_NotImplementedError():
     test_cs = cs.ControlSystem()
     with pytest.raises(NotImplementedError):
-        test_cs.get_single('dummy')
+        test_cs.get_single('dummy', 'throw')
     with pytest.raises(NotImplementedError):
-        test_cs.get_multiple(['dummy1', 'dummy_2'])
+        test_cs.get_multiple(['dummy1', 'dummy_2'], 'throw')
     with pytest.raises(NotImplementedError):
-        test_cs.set_single('dummy', 1)
+        test_cs.set_single('dummy', 1, 'throw')
     with pytest.raises(NotImplementedError):
-        test_cs.set_multiple(['dummy_1', 'dummy_2'], [1, 2])
+        test_cs.set_multiple(['dummy_1', 'dummy_2'], [1, 2], 'throw')
 
 
 def test_DataSource_throws_NotImplementedError():
@@ -20,9 +20,9 @@ def test_DataSource_throws_NotImplementedError():
     with pytest.raises(NotImplementedError):
         test_ds.get_fields()
     with pytest.raises(NotImplementedError):
-        test_ds.get_value('field', 'handle')
+        test_ds.get_value('field', 'handle', 'throw')
     with pytest.raises(NotImplementedError):
-        test_ds.set_value('field', 0.0)
+        test_ds.set_value('field', 0.0, 'throw')
 
 
 def test_Device_throws_NotImplementedError():
@@ -30,6 +30,6 @@ def test_Device_throws_NotImplementedError():
     with pytest.raises(NotImplementedError):
         test_d.is_enabled()
     with pytest.raises(NotImplementedError):
-        test_d.set_value(0.0)
+        test_d.set_value(0.0, 'throw')
     with pytest.raises(NotImplementedError):
-        test_d.get_value()
+        test_d.get_value('handle', 'throw')

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -75,7 +75,7 @@ def test_lattice_get_elements_with_n_elements(simple_lattice):
     simple_lattice.add_element(elem)
     assert simple_lattice[1] == elem
     assert simple_lattice.get_elements() == [elem, elem]
-    simple_lattice._lattice = []
+    simple_lattice._elements = []
     assert len(simple_lattice) == 0
     with pytest.raises(ValueError):
         simple_lattice.get_elements()

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -30,7 +30,7 @@ def test_device_methods_raise_DataSourceException_if_no_live_data_source(simple_
         basic_lattice.get_device('x')
 
 
-def test_get_unitconv_raises_FieldException_if_no_uc_for_that_field(simple_lattice):
+def test_get_unitconv_raises_FieldException_if_no_uc_for_field(simple_lattice):
     with pytest.raises(pytac.exceptions.FieldException):
         simple_lattice.get_unitconv('not_a_field')
 
@@ -49,7 +49,7 @@ def test_set_value_raises_exceptions_correctly(simple_lattice):
         simple_lattice.set_value('not_a_field', 0)
 
 
-def test_get_element_devices_raises_exceptions_correctly_for_mismatched_family(simple_lattice):
+def test_get_element_devices_raises_ValueError_for_mismatched_family(simple_lattice):
     with pytest.raises(ValueError):
         devices = simple_lattice.get_element_devices('not-a-family', 'x')
     basic_element = simple_lattice.get_elements('family')[0]
@@ -70,14 +70,18 @@ def test_get_element_device_names(simple_lattice):
                                                    'x') == ['x_device']
 
 
-def test_lattice_with_n_elements(simple_lattice):
+def test_lattice_get_elements_with_n_elements(simple_lattice):
     elem = simple_lattice[0]
     simple_lattice.add_element(elem)
     assert simple_lattice[1] == elem
     assert simple_lattice.get_elements() == [elem, elem]
+    simple_lattice._lattice = []
+    assert len(simple_lattice) == 0
+    with pytest.raises(ValueError):
+        simple_lattice.get_elements()
 
 
-def test_lattice_get_element_with_family(simple_lattice):
+def test_lattice_get_elements_with_family(simple_lattice):
     elem = simple_lattice[0]
     elem.add_to_family('fam')
     assert simple_lattice.get_elements('fam') == [elem]

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -103,7 +103,7 @@ def test_get_all_families(simple_lattice):
 
 def test_get_element_values(simple_lattice):
     simple_lattice.get_element_values('family', 'x', pytac.RB)
-    simple_lattice.get_element_devices('family', 'x')[0].get_value.assert_called_with(pytac.RB)
+    simple_lattice.get_element_devices('family', 'x')[0].get_value.assert_called_with(pytac.RB, True)
 
 
 @pytest.mark.parametrize('dtype, expected',
@@ -123,8 +123,7 @@ def test_get_element_values_returns_numpy_array_if_requested(simple_lattice,
 
 def test_set_element_values(simple_lattice):
     simple_lattice.set_element_values('family', 'x', [1])
-    simple_lattice.get_element_devices('family',
-                                       'x')[0].set_value.assert_called_with(1)
+    simple_lattice.get_element_devices('family', 'x')[0].set_value.assert_called_with(1, True)
 
 
 def test_set_element_values_length_mismatch_raises_IndexError(simple_lattice):

--- a/test/test_machine.py
+++ b/test/test_machine.py
@@ -172,7 +172,7 @@ def test_quad_unitconv_known_failing_test():
 
     uc = pytac.units.PchipUnitConv([50.0, 100.0, 180.0],
                                    [-4.95, -9.85, -17.56])
-    uc._post_eng_to_phys = pytac.load_csv.get_div_rigidity(LAT_ENERGY)
-    uc._pre_phys_to_eng = pytac.load_csv.get_mult_rigidity(LAT_ENERGY)
+    uc._post_eng_to_phys = pytac.utils.get_div_rigidity(LAT_ENERGY)
+    uc._pre_phys_to_eng = pytac.utils.get_mult_rigidity(LAT_ENERGY)
     numpy.testing.assert_allclose(uc.eng_to_phys(70), -0.69133465)
     numpy.testing.assert_allclose(uc.phys_to_eng(-0.7), 70.8834284954)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,19 +6,19 @@ from pytac import utils
 
 
 def test_rigidity():
-    numpy.testing.assert_almost_equal(utils.get_rigidity(3000000000),
+    numpy.testing.assert_almost_equal(utils.get_rigidity(3.e+9),
                                       10006922.85594456)
 
 
 def test_get_div_rigidity():
-    div = utils.get_div_rigidity(3000000000)
+    div = utils.get_div_rigidity(3.e+9)
     assert isinstance(div, types.FunctionType)
     numpy.testing.assert_almost_equal(div(numpy.pi), 3.139419278848089e-07)
     numpy.testing.assert_almost_equal(div(1.e+8), 9.993081933333334)
 
 
 def test_get_mult_rigidity():
-    mult = utils.get_mult_rigidity(3000000000)
+    mult = utils.get_mult_rigidity(3.e+9)
     assert isinstance(mult, types.FunctionType)
     numpy.testing.assert_almost_equal(mult(numpy.pi), 31437675.329275224)
     numpy.testing.assert_almost_equal(mult(1.e-8), 0.10006922855944561)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,24 @@
+import types
+
 import numpy
 
 from pytac import utils
 
 
 def test_rigidity():
-    numpy.testing.assert_allclose(utils.rigidity(3000), 10.0069227)
+    numpy.testing.assert_almost_equal(utils.get_rigidity(3000000000),
+                                      10006922.85594456)
+
+
+def test_get_div_rigidity():
+    div = utils.get_div_rigidity(3000000000)
+    assert isinstance(div, types.FunctionType)
+    numpy.testing.assert_almost_equal(div(numpy.pi), 3.139419278848089e-07)
+    numpy.testing.assert_almost_equal(div(1.e+8), 9.993081933333334)
+
+
+def test_get_mult_rigidity():
+    mult = utils.get_mult_rigidity(3000000000)
+    assert isinstance(mult, types.FunctionType)
+    numpy.testing.assert_almost_equal(mult(numpy.pi), 31437675.329275224)
+    numpy.testing.assert_almost_equal(mult(1.e-8), 0.10006922855944561)

--- a/utils/load_unitconv.m
+++ b/utils/load_unitconv.m
@@ -42,12 +42,12 @@ for i = 1:length(db_indexes)
     fprintf(f_units, '%d,%s,null,%d,%s,%s\n', renamedIndexes(db_indexes(i)), 'db0', 0, 'm^-1', 'A');
 end
 rfs = getfamilydata('RF');
-if length(rfs.ElementList) > 1
+if length(rfs.ElementList) == 1
+    fprintf(f_units, '%d,%s,null,%d,%s,%s\n', renamedIndexes(family2atindex('RF')), 'f', 0, 'Hz', 'Hz');
+else
     for i = 1:length(rfs.AT.ATIndex)
         fprintf(f_units, '%d,%s,null,%d,%s,%s\n', renamedIndexes(rfs.AT.ATIndex(i)), 'f', 0, 'Hz', 'Hz');
     end
-else
-    fprintf(f_units, '%d,%s,null,%d,%s,%s\n', 1490, 'f', 0, 'Hz', 'Hz');
 end
 
 for i = 1:length(quad_families)


### PR DESCRIPTION
This is pretty much everything that was left on my todo list for pytac.

If you remember we discovered that our errors were being chained rather than replaced, when using Python 3, e.g.
```
>>> lattice.get_value('not_a_field')
Traceback (most recent call last):
  File "/home/jzs47954/git/pytac/pytac/data_source.py", line 315, in get_value
    throw (bool): if True, ControlSystemException will be raised on
KeyError: 'not_a_field'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jzs47954/git/pytac/pytac/data_source.py", line 196, in get_value
    if units == pytac.DEFAULT:
  File "/home/jzs47954/git/pytac/pytac/data_source.py", line 318, in get_value
    Returns:
pytac.exceptions.FieldException: No field not_a_field on data source <pytac.data_source.DeviceDataSource object at 0x7fb0ba8a9cc0>.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jzs47954/git/pytac/pytac/lattice.py", line 174, in get_value
    try:
  File "/home/jzs47954/git/pytac/pytac/data_source.py", line 204, in get_value
    target=units)
pytac.exceptions.FieldException: No field not_a_field on manager <pytac.data_source.DataSourceManager object at 0x7fb0ba88c080>.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jzs47954/git/pytac/pytac/lattice.py", line 180, in get_value
    except FieldException:
pytac.exceptions.FieldException: Lattice <pytac.lattice.EpicsLattice object at 0x7fb0ba88c128> does not have field not_a_field on data source default
```
According to [pep3134](https://www.python.org/dev/peps/pep-3134/) this is the intended behaviour now; [pep415](https://www.python.org/dev/peps/pep-0415/) gives ways to avoid this, but they are not compatible with python 2.7 as far as I can tell. So for it seems like we are stuck with this behaviour.
