### PR TITLE
Pytac families should be case-insensitive.

### DIFF
--- a/pytac/element.py
+++ b/pytac/element.py
@@ -16,13 +16,14 @@ class Element(object):
         name (str): The name identifying the element.
         type_ (str): The type of the element.
         length (float): The length of the element in metres.
-        families (set): The families this element is a member of.
 
     .. Private Attributes:
            _lattice (Lattice): The lattice to which the element belongs.
            _data_source_manager (DataSourceManager): A class that manages the
                                                       data sources associated
                                                       with this element.
+           _families (set): The families this element is a member of, stored
+                            as lowercase strings.
     """
 
     def __init__(self, length, element_type, name=None, lattice=None):
@@ -38,7 +39,8 @@ class Element(object):
         self.name = name
         self.type_ = element_type
         self.length = length
-        self.families = set()
+        # Families are case insensitive but stored in lowercase.
+        self._families = set()
         self._lattice = lattice
         self._data_source_manager = DataSourceManager()
 
@@ -73,6 +75,11 @@ class Element(object):
             return None
         else:
             return int(self.s / self._lattice.cell_length) + 1
+
+    @property
+    def families(self):
+        """set(str): All families that this element is in."""
+        return set(self._families)
 
     def __str__(self):
         """Return a representation of an element, as a string.
@@ -197,7 +204,18 @@ class Element(object):
         Args:
             family (str): Represents the name of the family.
         """
-        self.families.add(family)
+        self._families.add(family.lower())
+
+    def is_in_family(self, family):
+        """Return true if the element is in the specified family.
+
+        Args:
+            family (str): Family to check.
+
+        Returns:
+            true if element is in the specified family.
+        """
+        return family.lower() in self._families
 
     def get_value(
         self,

--- a/pytac/lattice.py
+++ b/pytac/lattice.py
@@ -323,7 +323,7 @@ class Lattice(object):
             if len(elements) == 0:
                 raise ValueError("No elements in lattice {0}.".format(self))
         else:
-            elements = [e for e in self._elements if family in e.families]
+            elements = [e for e in self._elements if e.is_in_family(family)]
             if len(elements) == 0:
                 raise ValueError("No elements in family {0}.".format(family))
         if cell is not None:

--- a/pytac/load_csv.py
+++ b/pytac/load_csv.py
@@ -125,8 +125,9 @@ def load_unitconv(directory, mode, lattice):
                     # Each element needs its own unitconv object as
                     # it may for example have different limit.
                     uc = copy.copy(unitconvs[int(item["uc_id"])])
-                    if element.families.intersection(
-                        ("HSTR", "VSTR", "QUAD", "SEXT", "BEND")
+                    if any(
+                        element.is_in_family(f)
+                        for f in ("HSTR", "VSTR", "QUAD", "SEXT", "BEND")
                     ):
                         energy = lattice.get_value("energy", units=pytac.PHYS)
                         uc.set_post_eng_to_phys(utils.get_div_rigidity(energy))

--- a/test/test_element.py
+++ b/test/test_element.py
@@ -42,10 +42,14 @@ def test_element_properties_with_lattice():
     assert e2.cell == 2
 
 
-def test_add_element_to_family():
+def test_add_element_to_family_and_case_insensitive_retrieval():
     e = Element(6.0, "QUAD", "dummy")
-    e.add_to_family("fam")
+    e.add_to_family("FAM")
+    # Lowercase only
     assert "fam" in e.families
+    assert "FAM" not in e.families
+    assert e.is_in_family("fam")
+    assert e.is_in_family("FAM")
 
 
 def test_device_methods_raise_DataSourceException_if_no_live_data_source(


### PR DESCRIPTION
There is no use-case for having two families that differ only in case.